### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 MCP Server for the GitHub API, enabling file operations, repository management, search functionality, and more.
 
+<a href="https://glama.ai/mcp/servers/qmvm4mx87p"><img width="380" height="200" src="https://glama.ai/mcp/servers/qmvm4mx87p/badge" alt="GitHub Server Plus MCP server" /></a>
+
 ### Features
 
 - **Automatic Branch Creation**: When creating/updating files or pushing changes, branches are automatically created if they don't exist


### PR DESCRIPTION
This PR adds a badge for the [GitHub MCP Server Plus](https://glama.ai/mcp/servers/qmvm4mx87p) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/qmvm4mx87p"><img width="380" height="200" src="https://glama.ai/mcp/servers/qmvm4mx87p/badge" alt="GitHub Server Plus MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.